### PR TITLE
Fixing issue #3 and US2RangeCondition max value bug

### DIFF
--- a/US2FormValidationFramework/source/base/US2ValidatorTextFieldPrivate.m
+++ b/US2FormValidationFramework/source/base/US2ValidatorTextFieldPrivate.m
@@ -63,8 +63,9 @@
         [_validatorTextField validatorTextFieldPrivate:self violatedConditions:conditions];
     
     // If condition is NULL no condition failed
-    if (NO == _validatorTextField.shouldAllowViolation
+    if ((NO == _validatorTextField.shouldAllowViolation
         || NO == [conditions conditionAtIndex:0].shouldAllowViolation)
+        && range.location != 0)
     {
         return [conditions conditionAtIndex:0] == nil;
     }

--- a/US2FormValidationFramework/source/conditions/US2ConditionRange.m
+++ b/US2FormValidationFramework/source/conditions/US2ConditionRange.m
@@ -60,7 +60,7 @@
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:regexString options:0 error:&error];
     NSUInteger numberOfMatches = [regex numberOfMatchesInString:string options:0 range:NSMakeRange(0, string.length)];
     
-    return numberOfMatches > 0;
+    return numberOfMatches == 1;
 }
 
 

--- a/US2FormValidationFrameworkSample/sample/MyProjectValidatorName.m
+++ b/US2FormValidationFrameworkSample/sample/MyProjectValidatorName.m
@@ -41,8 +41,8 @@
         [self addCondition:[[[MyProjectConditionName alloc] init] autorelease]];
         
         US2ConditionRange *rangeCondition   = [[[US2ConditionRange alloc] init] autorelease];
-        rangeCondition.range                = NSMakeRange(2, UINT16_MAX);
-        rangeCondition.shouldAllowViolation = YES;
+        rangeCondition.range                = NSMakeRange(1, 15);
+        rangeCondition.shouldAllowViolation = NO;
         
         [self addCondition:rangeCondition];
     }


### PR DESCRIPTION
- Fixing issue #3 by implementing an additional check at `US2ValidatorTextFieldPrivate.m:68`.
- Also fixing a bug in `US2ConditionRange.m` where the max range value was not triggering a violation.
  This was because of the regex check `.{%d,%d}` matching more than one result and the condition passing for more than one match `return numberOfMatches > 0;`. For example `.{1,3}` on the string `aaaa` returns two matches, one for `a` and another for `aaa` which is incorrect. To catch this problem i've updated the method to only accept 1 result as valid. 
- Updated the sample app to implement a min and max range check on the `Name` field to illustrate the fixes working correctly. 
