### PR TITLE
Cleanup notification observers

### DIFF
--- a/US2FormValidationFramework/source/base/US2ValidatorTextField.m
+++ b/US2FormValidationFramework/source/base/US2ValidatorTextField.m
@@ -73,6 +73,11 @@
 
 - (void)dealloc
 {
+    // Remove notification observers
+    NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+    [notificationCenter removeObserver:_validatorTextFieldPrivate name:UITextFieldTextDidChangeNotification object:self];
+    [notificationCenter removeObserver:_validatorTextFieldPrivate name:UITextFieldTextDidEndEditingNotification object:self];
+    
     [_validator release];
     [_validatorTextFieldPrivate release];
     

--- a/US2FormValidationFramework/source/base/US2ValidatorTextView.m
+++ b/US2FormValidationFramework/source/base/US2ValidatorTextView.m
@@ -73,6 +73,9 @@
 
 - (void)dealloc
 {
+    // Remove notification observer
+    [[NSNotificationCenter defaultCenter] removeObserver:_validatorTextViewPrivate name:UITextViewTextDidEndEditingNotification object:self];
+    
     [_validator release];    
     [_validatorTextViewPrivate release];
     


### PR DESCRIPTION
I had a crash which I could only explain by not removed text field notification observers in the US2FormValidator. In any case it is good practice to clean up afterwards.

0   CoreFoundation 0x34dfe88f **exceptionPreprocess + 162
1   libobjc.A.dylib 0x36dcc259 objc_exception_throw + 32
2   CoreFoundation 0x34e01a9b -[NSObject doesNotRecognizeSelector:] + 174
3   CoreFoundation 0x34e00915 ___forwarding_** + 300
4   CoreFoundation 0x34d5b650 _CF_forwarding_prep_0 + 48
5   Foundation 0x336354ff __57-[NSNotificationCenter addObserver:selector:name:object:]_block_invoke_0 + 18
6   CoreFoundation 0x34dca547 ___CFXNotificationPost_block_invoke_0 + 70
7   CoreFoundation 0x34d56097 _CFXNotificationPost + 1406
8   Foundation 0x335a93eb -[NSNotificationCenter postNotificationName:object:userInfo:] + 66
9   Foundation 0x335aac1b -[NSNotificationCenter postNotificationName:object:] + 30
10  UIKit 0x314aaa3b -[UITextField fieldEditorDidChange:] + 278
