### PR TITLE
fixed regex for email

### DIFF
--- a/US2FormValidationFramework/source/conditions/US2ConditionEmail.m
+++ b/US2FormValidationFramework/source/conditions/US2ConditionEmail.m
@@ -35,7 +35,7 @@
         string = [NSString string];
     
     NSError *error             = NULL;
-    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"^[+\\w\\.\\-']+@[a-zA-Z0-9-]+(\\.[a-zA-Z]{2,})+$" options:NSRegularExpressionCaseInsensitive error:&error];
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"^[+\\w\\.\\-']+@[a-zA-Z0-9-]+(\\.[a-zA-Z0-9-]+)*(\\.[a-zA-Z]{2,})+$" options:NSRegularExpressionCaseInsensitive error:&error];
     NSUInteger numberOfMatches = [regex numberOfMatchesInString:string options:0 range:NSMakeRange(0, string.length)];
     
     return numberOfMatches == 1;


### PR DESCRIPTION
subdomain email addresses like "test@test.so-net.ne.jp" should be valid
