### PR TITLE
Update to podspec so that localized resources are correctly pulled in for CocoaPods installation

### DIFF
--- a/US2FormValidator.podspec
+++ b/US2FormValidator.podspec
@@ -9,6 +9,6 @@ Pod::Spec.new do |s|
   s.platform     = :ios
   s.source       = { :git => 'https://github.com/ustwo/US2FormValidator.git', :tag => '1.0.8' }
   s.source_files = 'US2FormValidationFramework/source/**/*.{h,m}'
-  s.resource     = 'US2FormValidationFramework/source/US2Localizable'
+  s.resources    = 'US2FormValidationFramework/US2Localizable/*'
   s.clean_paths  = 'Documentation', 'US2FormValidationFrameworkSample', 'US2FormValidationFramework/tests', 'US2FormValidationFramework/documentation', 'US2FormValidationFramework/US2FormValidationFramework.xcodeproj'
 end


### PR DESCRIPTION
The localized resources were not being correctly pulled into the target project when US2FormValidator was installed via CocoaPods.
