### PR TITLE
fixing 2 analyzer warnings about unused instance variables

### DIFF
--- a/US2FormValidationFramework/source/base/US2ValidatorTextField.h
+++ b/US2FormValidationFramework/source/base/US2ValidatorTextField.h
@@ -50,7 +50,6 @@
     id <US2ValidatorUIDelegate, UITextFieldDelegate> _validatorUIDelegate;
     US2Validator                                     *_validator;
     US2ValidatorTextFieldPrivate                     *_validatorTextFieldPrivate;
-    BOOL                                             _shouldAllowViolation;
     BOOL                                             _validateOnFocusLossOnly;
 }
 

--- a/US2FormValidationFramework/source/base/US2ValidatorTextView.h
+++ b/US2FormValidationFramework/source/base/US2ValidatorTextView.h
@@ -50,7 +50,6 @@
     id <US2ValidatorUIDelegate, UITextViewDelegate> _validatorUIDelegate;
     US2Validator                                    *_validator;
     US2ValidatorTextViewPrivate                     *_validatorTextViewPrivate;
-    BOOL                                            _shouldAllowViolation;
     BOOL                                            _validateOnFocusLossOnly;
 }
 


### PR DESCRIPTION
Really small PR. Just saw two warnings when running the analyzer. These variables don't seem to be used.

![screenshot 2015-06-18 21 50 19](https://cloud.githubusercontent.com/assets/166013/8247352/341a27c0-1604-11e5-87a9-f42a8635d36f.png)
